### PR TITLE
CartesianTrajectoryController: Make inverse kinematics a parameter on…

### DIFF
--- a/cartesian_trajectory_controller/CMakeLists.txt
+++ b/cartesian_trajectory_controller/CMakeLists.txt
@@ -109,7 +109,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} ik_solver_example
   CATKIN_DEPENDS
   cartesian_interface
   cartesian_trajectory_interpolation
@@ -137,11 +137,15 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/cartesian_trajectory_controller.cpp
 )
+add_library(ik_solver_example
+  src/ik_solver_example.cpp
+)
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(ik_solver_example ${ik_solver_example_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
@@ -160,6 +164,9 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+target_link_libraries(ik_solver_example
   ${catkin_LIBRARIES}
 )
 
@@ -190,6 +197,11 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
+install(TARGETS ik_solver_example
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
@@ -201,6 +213,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 install(FILES
   ${PROJECT_NAME}_plugin.xml
+  ik_solver_example_plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/cartesian_trajectory_controller/README.md
+++ b/cartesian_trajectory_controller/README.md
@@ -58,6 +58,22 @@ jnt_cartesian_traj_controller:
 
 ```
 
+## Customizing Inverse Kinematics
+
+Plugins allow you to implement your own (possibly more advanced) Inverse Kinematics algorithm. For instance, you may wish
+to use additional sensors in your environment and react online to objects and collisions.
+
+Take a look at the provided *example_solver* on how to use the plugin mechanism for your custom implementation.
+You can then specify the *ik_solver* at startup in form of a controller-local parameter in the .yaml controller config file:
+
+```yaml
+jnt_cartesian_traj_controller:
+     type: "position_controllers/CartesianTrajectoryController"
+     ik_solver: "example_solver"
+     ...
+
+```
+
 ***
 <!-- 
     ROSIN acknowledgement from the ROSIN press kit

--- a/cartesian_trajectory_controller/ik_solver_example_plugin.xml
+++ b/cartesian_trajectory_controller/ik_solver_example_plugin.xml
@@ -1,0 +1,11 @@
+<library path="lib/libik_solver_example">
+
+  <class name="example_solver"
+         type="cartesian_ros_control::ExampleIKSolver"
+         base_class_type="cartesian_ros_control::IKSolver">
+    <description>
+      An example IK solver for joint-based Cartesian trajectory controllers
+    </description>
+  </class>
+
+</library>

--- a/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.h
+++ b/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.h
@@ -48,6 +48,9 @@
 #include "cartesian_trajectory_interpolation/cartesian_trajectory_segment.h"
 #include "kdl/chainfksolver.hpp"
 #include <cartesian_trajectory_interpolation/cartesian_state.h>
+#include <pluginlib/class_loader.h>
+#include <inverse_kinematics/ik_solver_base.h>
+
 
 // KDL
 #include <kdl/chain.hpp>
@@ -187,7 +190,8 @@ namespace cartesian_ros_control
 
 
       private:
-        std::unique_ptr<KDL::ChainIkSolverPos_LMA> ik_solver_;
+        std::unique_ptr<pluginlib::ClassLoader<IKSolver> > solver_loader_;
+        boost::shared_ptr<IKSolver> ik_solver_;
     };
 
 

--- a/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.h
+++ b/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.h
@@ -191,7 +191,7 @@ namespace cartesian_ros_control
 
       private:
         std::unique_ptr<pluginlib::ClassLoader<IKSolver> > solver_loader_;
-        boost::shared_ptr<IKSolver> ik_solver_;
+        std::unique_ptr<IKSolver> ik_solver_;
     };
 
 

--- a/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.hpp
+++ b/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.hpp
@@ -261,7 +261,27 @@ namespace cartesian_ros_control
       return false;
     };
 
-    ik_solver_ = std::make_unique<KDL::ChainIkSolverPos_LMA>(robot_chain_);
+    // Load user specified inverse kinematics solver
+    std::string solver_type = "example_solver"; // Default
+    controller_nh.getParam("ik_solver", solver_type);
+
+    solver_loader_ = std::make_unique<pluginlib::ClassLoader<IKSolver>>(
+          "cartesian_trajectory_controller", "cartesian_ros_control::IKSolver");
+    try
+    {
+      ik_solver_ = solver_loader_->createInstance(solver_type);
+    }
+    catch (pluginlib::PluginlibException& ex)
+    {
+      ROS_ERROR_STREAM(ex.what());
+      return false;
+    }
+
+    if (!ik_solver_->init(robot_chain_, root_nh, controller_nh))
+    {
+      return false;
+    }
+
     return true;
   }
 
@@ -285,7 +305,7 @@ namespace cartesian_ros_control
     }
 
     // Compute inverse kinematics
-    ik_solver_->CartToJnt(current, goal, target);
+    ik_solver_->cartToJnt(current, goal, target);
 
     // Command each joint
     for (size_t i = 0; i < size; ++i)

--- a/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.hpp
+++ b/cartesian_trajectory_controller/include/cartesian_trajectory_controller/control_policies.hpp
@@ -262,14 +262,13 @@ namespace cartesian_ros_control
     };
 
     // Load user specified inverse kinematics solver
-    std::string solver_type = "example_solver"; // Default
-    controller_nh.getParam("ik_solver", solver_type);
+    std::string solver_type = controller_nh.param("ik_solver", std::string("example_solver"));
 
     solver_loader_ = std::make_unique<pluginlib::ClassLoader<IKSolver>>(
           "cartesian_trajectory_controller", "cartesian_ros_control::IKSolver");
     try
     {
-      ik_solver_ = solver_loader_->createInstance(solver_type);
+      ik_solver_.reset(solver_loader_->createUnmanagedInstance(solver_type));
     }
     catch (pluginlib::PluginlibException& ex)
     {

--- a/cartesian_trajectory_controller/include/inverse_kinematics/ik_solver_base.h
+++ b/cartesian_trajectory_controller/include/inverse_kinematics/ik_solver_base.h
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+
+//-----------------------------------------------------------------------------
+/*!\file    ik_solver_base.h
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/12
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include <kdl/jntarray.hpp>
+#include <kdl/frames.hpp>
+#include <kdl/chain.hpp>
+#include <ros/ros.h>
+
+namespace cartesian_ros_control
+{
+
+  /**
+   * @brief Base class for Inverse Kinematics (IK) solvers
+   *
+   * This base class is meant to provide an interface for custom IK implementations.
+   * The joint-based control policies in the Cartesian trajectory
+   * controller will need some form of IK solver. This allows you to implement
+   * your own (possibly more advanced) algorithm. For instance, you may wish
+   * to consider collision checking by reacting ad-hoc to objects
+   * that additional sensors perceive in your environment.
+   */
+  class IKSolver
+  {
+    public:
+      IKSolver(){};
+      virtual ~IKSolver(){};
+
+      /**
+       * @brief Initialize the solver
+       *
+       * @param robot_chain Representation of the robot kinematics
+       *
+       * @param root_nh A NodeHandle in the root of the controller manager namespace.
+       *
+       * @param controller_nh A NodeHandle in the namespace of the controller.
+       * This is where the Cartesian trajectory controller-specific configuration resides.
+       *
+       * @return True if initialization was successful.
+       */
+      virtual bool init(const KDL::Chain& robot_chain, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) = 0;
+
+      /**
+       * @brief Compute Inverse Kinematics
+       *
+       * @param q_init Vector of initial joint positions
+       * @param goal Goal pose with respect to the robot base
+       * @param q_out Vector of suitable joint positions
+       *
+       * @return 0 if successful. Derived classes implement specializations.
+       */
+      virtual int cartToJnt(const KDL::JntArray& q_init, const KDL::Frame& goal, KDL::JntArray& q_out) = 0;
+  };
+
+}

--- a/cartesian_trajectory_controller/include/inverse_kinematics/ik_solver_example.h
+++ b/cartesian_trajectory_controller/include/inverse_kinematics/ik_solver_example.h
@@ -1,0 +1,89 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    ik_solver_example.h
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/12
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include <inverse_kinematics/ik_solver_base.h>
+#include <kdl/chainiksolverpos_lma.hpp>
+#include <kdl/chain.hpp>
+#include <memory>
+
+namespace cartesian_ros_control
+{
+  /**
+   * @brief A wrapper around KDL's Levenberg Marquardt solver
+   *
+   * This is the default Inverse Kinematics (IK) solver for the
+   * cartesian_trajectory_controller.
+   */
+  class ExampleIKSolver : public IKSolver
+  {
+    public:
+      ExampleIKSolver(){};
+      ~ExampleIKSolver(){};
+
+      /**
+       * @brief Initialize the solver
+       *
+       * Only the kinematics chain is used.
+       *
+       */
+      bool init(const KDL::Chain& robot_chain, ros::NodeHandle&, ros::NodeHandle&) override
+      {
+        robot_chain_ = robot_chain;
+        lma_solver_ = std::make_unique<KDL::ChainIkSolverPos_LMA>(robot_chain_);
+        return true;
+      };
+
+      /**
+       * @brief Compute Inverse Kinematics with KDL's Levenberg Marquardt solver.
+       *
+       */
+      virtual int cartToJnt(const KDL::JntArray& q_init, const KDL::Frame& goal, KDL::JntArray& q_out) override
+      {
+        return lma_solver_->CartToJnt(q_init, goal, q_out);
+      };
+
+    private:
+      std::unique_ptr<KDL::ChainIkSolverPos_LMA> lma_solver_;
+      KDL::Chain robot_chain_;
+  };
+}
+
+

--- a/cartesian_trajectory_controller/package.xml
+++ b/cartesian_trajectory_controller/package.xml
@@ -98,5 +98,12 @@
     rospack plugins - -attrib=plugin controller_interface
     -->
     <controller_interface plugin="${prefix}/cartesian_trajectory_controller_plugin.xml"/>
+
+    <!--
+    Use
+    rospack plugins - -attrib=plugin cartesian_trajectory_controller
+    to check for available IK solvers
+    -->
+    <cartesian_trajectory_controller plugin="${prefix}/ik_solver_example_plugin.xml"/>
   </export>
 </package>

--- a/cartesian_trajectory_controller/src/ik_solver_example.cpp
+++ b/cartesian_trajectory_controller/src/ik_solver_example.cpp
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    ik_solver_example.cpp
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/12
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#include <inverse_kinematics/ik_solver_example.h>
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+/**
+ * \class cartesian_ros_control::ExampleIKSolver
+ *
+ * You may explicitly specify this solver with \a "example_solver" as \a
+ * ik_solver in the controllers.yaml configuration file:
+ *
+ * \code{.yaml}
+ * <name_of_your_controller>:
+ *     type: "position_controllers/CartesianTrajectoryController"
+ *     ik_solver: "example_solver"
+ *     ...
+ * \endcode
+ *
+ */
+PLUGINLIB_EXPORT_CLASS(cartesian_ros_control::ExampleIKSolver, cartesian_ros_control::IKSolver)


### PR DESCRIPTION
… startup

This allows users of the joint-based versions to implement their own IK
solvers with plugins.
This shall give them the option to implement more complex algorithms for
special use cases, such as collision avoidance during Cartesian
trajectory execution.
The default implementation is KDL's Levenberg Marquardt solver.