### PR TITLE
Add trajectory interpolation tests

### DIFF
--- a/cartesian_trajectory_interpolation/CMakeLists.txt
+++ b/cartesian_trajectory_interpolation/CMakeLists.txt
@@ -212,6 +212,8 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(cartesian_trajectory_segment_test test/cartesian_trajectory_segment_test.cpp)
   target_link_libraries(cartesian_trajectory_segment_test ${catkin_LIBRARIES} ${PROJECT_NAME})
 
+  catkin_add_gtest(cartesian_trajectory_test test/cartesian_trajectory_test.cpp)
+  target_link_libraries(cartesian_trajectory_test ${catkin_LIBRARIES} ${PROJECT_NAME})
 
 endif()
 

--- a/cartesian_trajectory_interpolation/CMakeLists.txt
+++ b/cartesian_trajectory_interpolation/CMakeLists.txt
@@ -205,6 +205,13 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(cartesian_state_test test/cartesian_state_test.cpp)
+  target_link_libraries(cartesian_state_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+
+
+endif()
+
 ## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_cartesian_trajectory_interpolation.cpp)
 # if(TARGET ${PROJECT_NAME}-test)

--- a/cartesian_trajectory_interpolation/CMakeLists.txt
+++ b/cartesian_trajectory_interpolation/CMakeLists.txt
@@ -209,6 +209,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(cartesian_state_test test/cartesian_state_test.cpp)
   target_link_libraries(cartesian_state_test ${catkin_LIBRARIES} ${PROJECT_NAME})
 
+  catkin_add_gtest(cartesian_trajectory_segment_test test/cartesian_trajectory_segment_test.cpp)
+  target_link_libraries(cartesian_trajectory_segment_test ${catkin_LIBRARIES} ${PROJECT_NAME})
+
 
 endif()
 

--- a/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_state.h
+++ b/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_state.h
@@ -51,10 +51,16 @@ namespace cartesian_ros_control
    */
   struct CartesianState
   {
-    CartesianState() = default;
+
+    /**
+     * @brief Initializes all quantities to zero and sets the orientation quaternion to identity
+     */
+    CartesianState();
 
     /**
      * @brief Convenience constructor for ROS messages
+     *
+     * Implicitly normalizes the point's orientation quaternion.
      *
      * @param point The desired state
      */
@@ -87,6 +93,16 @@ namespace cartesian_ros_control
      * @return The orientation in axis-angle notation
      */
     Eigen::Vector3d rot() const {Eigen::AngleAxisd a(q); return a.axis() * a.angle();};
+
+    /**
+     * @brief Stream operator for testing and debugging
+     *
+     * @param os The output stream
+     * @param state The CartesianState
+     *
+     * @return Reference to the stream for chaining
+     */
+    friend std::ostream& operator<<(std::ostream &os, const CartesianState& state);
 
     // Pose
     Eigen::Vector3d p; ///< position

--- a/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory.h
+++ b/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory.h
@@ -81,7 +81,7 @@ namespace cartesian_ros_control
        *
        * @param ros_trajectory The Cartesian trajectory composed with ROS message types
        *
-       * @return True if \b ros_trajectory is valid, else false.
+       * @return True if \b ros_trajectory has increasing waypoints in time, else false.
        */
       bool init(const cartesian_control_msgs::CartesianTrajectory& ros_trajectory);
 

--- a/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
+++ b/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
@@ -89,7 +89,7 @@ namespace cartesian_ros_control
        * @brief State of a 7-dimensional Spline
        *
        * The first three dimensions represent Cartesian translation and the last
-       * four represent the rotation quaternion.  Each dimension has its own
+       * four represent the rotation quaternion (w, x, y, z).  Each dimension has its own
        * position, velocity and acceleration value.
        *
        */
@@ -127,23 +127,46 @@ namespace cartesian_ros_control
        */
       void sample(const Time& time, CartesianState& state) const;
 
-      /**
-       * @brief Convert a CartesianState into a cartesian_ros_control::SplineState
-       *
-       * The computation of quaternion velocities and accelerations from
-       * Cartesian angular velocities and accelerations is based on
-       * <a href="https://math.stackexchange.com/questions/1792826/estimate-angular-velocity-and-acceleration-from-a-sequence-of-rotations">this blog post</a>.
-       * \note SplineState has the velocities and accelerations
-       * given in the body-local reference frame that is implicitly defined
-       * by \b state's pose. 
-       *
-       * @param state The CartesianState to convert
-       *
-       * @return The content of \b state in cartesian_ros_control::SplineState notation
-       */
-      SplineState convert(const CartesianState& state) const;
-
     private:
   };
+
+  /**
+   * @brief Stream operator for testing and debugging
+   *
+   * @param os The output stream
+   * @param state The SplineState
+   *
+   * @return Reference to the stream for chaining
+   */
+  std::ostream& operator<<(std::ostream &os, const CartesianTrajectorySegment::SplineState& state);
+
+  /**
+   * @brief Convert a CartesianState into a cartesian_ros_control::SplineState
+   *
+   * The computation of quaternion velocities and accelerations from
+   * Cartesian angular velocities and accelerations is based on
+   * <a href="https://math.stackexchange.com/questions/1792826">this blog post</a>.
+   * \note SplineState has the velocities and accelerations
+   * given in the body-local reference frame that is implicitly defined
+   * by \b state's pose. 
+   *
+   * @param state The CartesianState to convert
+   *
+   * @return The content of \b state in cartesian_ros_control::SplineState notation
+   */
+  CartesianTrajectorySegment::SplineState convert(const CartesianState& state);
+
+  /**
+   * @brief Convert a cartesian_ros_control::SplineState into a CartesianState
+   *
+   * The computation of Cartesian angular velocities and accelerations from
+   * quaternion velocities and accelerations is based on
+   * <a href="https://math.stackexchange.com/questions/1792826">this blog post</a>.
+   *
+   * @param state The SplineState to convert
+   *
+   * @return The content of \b state in CartesianState notation
+   */
+  CartesianState convert(const CartesianTrajectorySegment::SplineState& state);
 
 }

--- a/cartesian_trajectory_interpolation/package.xml
+++ b/cartesian_trajectory_interpolation/package.xml
@@ -62,6 +62,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>roscpp</exec_depend>
 
+  <test_depend>rosunit</test_depend>
+
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/cartesian_trajectory_interpolation/src/cartesian_state.cpp
+++ b/cartesian_trajectory_interpolation/src/cartesian_state.cpp
@@ -59,12 +59,32 @@ namespace my_tf2
 namespace cartesian_ros_control
 {
 
+  CartesianState::CartesianState()
+  {
+    p = Eigen::Vector3d::Zero();
+    q.x() = 0;
+    q.y() = 0;
+    q.z() = 0;
+    q.w() = 1;
+
+    v = Eigen::Vector3d::Zero();
+    v_dot = Eigen::Vector3d::Zero();
+
+    w = Eigen::Vector3d::Zero();
+    w_dot = Eigen::Vector3d::Zero();
+  }
+
 
   CartesianState::CartesianState(const cartesian_control_msgs::CartesianTrajectoryPoint& point)
   {
     // Pose
     tf2::fromMsg(point.pose.position, p);
     tf2::fromMsg(point.pose.orientation, q);
+    if (q.coeffs() == Eigen::Vector4d::Zero())
+    {
+      q.w() = 1;
+    }
+    q.normalize();
 
     // Velocity
     tf2::fromMsg(point.twist.linear, v);
@@ -107,4 +127,14 @@ namespace cartesian_ros_control
     return point;
   }
 
+  std::ostream& operator<<(std::ostream &out, const CartesianState& state)
+  {
+    out << "p:\n" << state.p << '\n';
+    out << "q:\n" << state.q.coeffs() << '\n';
+    out << "v:\n" << state.v << '\n';
+    out << "w:\n" << state.w << '\n';
+    out << "v_dot:\n" << state.v_dot << '\n';
+    out << "w_dot:\n" << state.w_dot;
+    return out;
+  }
 }

--- a/cartesian_trajectory_interpolation/src/cartesian_trajectory.cpp
+++ b/cartesian_trajectory_interpolation/src/cartesian_trajectory.cpp
@@ -64,6 +64,11 @@ namespace cartesian_ros_control
     // neighboring pairs.
     for (auto i = ros_trajectory.points.begin(); std::next(i) < ros_trajectory.points.end(); ++i)
     {
+      // Waypoints' time from start must strictly increase
+      if (i->time_from_start.toSec() >= std::next(i)->time_from_start.toSec())
+      {
+        return false;
+      }
       CartesianTrajectorySegment s(
           i->time_from_start.toSec(), CartesianState(*i),
           std::next(i)->time_from_start.toSec(), CartesianState(*std::next(i))

--- a/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
@@ -1,0 +1,156 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+
+//-----------------------------------------------------------------------------
+/*!\file    cartesian_state_test.cpp
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/20
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cartesian_trajectory_interpolation/cartesian_state.h>
+#include <Eigen/Dense>
+#include <Eigen/src/Geometry/Quaternion.h>
+#include <cartesian_control_msgs/CartesianTrajectoryPoint.h>
+
+using namespace cartesian_ros_control;
+
+TEST(TestCartesianState, EmptyStateIsZeroInitialized)  // except for quaternion w
+{
+  CartesianState state;
+  for (size_t i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(state.p[i], 0);
+    EXPECT_EQ(state.v[i], 0);
+    EXPECT_EQ(state.v_dot[i], 0);
+    EXPECT_EQ(state.w[i], 0);
+    EXPECT_EQ(state.w_dot[i], 0);
+  }
+  EXPECT_EQ(state.q.x(), 0);
+  EXPECT_EQ(state.q.y(), 0);
+  EXPECT_EQ(state.q.z(), 0);
+  EXPECT_EQ(state.q.w(), 1);
+}
+
+TEST(TestCartesianState, EmptyStateHasNormalizedQuaternion)
+{
+  CartesianState state;
+  Eigen::Quaterniond q;
+  q.w() = 1;
+  q.normalize();
+  EXPECT_DOUBLE_EQ(q.norm(), state.q.norm());
+}
+
+TEST(TestCartesianState, EmptyStateYieldsZeroRotationVector)
+{
+  CartesianState state;
+  EXPECT_EQ(Eigen::Vector3d::Zero(), state.rot());
+}
+
+TEST(TestCartesianState, EmptyStateYieldsNormalizedTrajectoryPoint)
+{
+  CartesianState state;
+  cartesian_control_msgs::CartesianTrajectoryPoint point;
+  point.pose.orientation.w = 1;
+
+  // Compact check if both `read` the same.
+  std::stringstream state_str;
+  std::stringstream point_str;
+  state_str << state.toMsg();
+  point_str << point;
+
+  EXPECT_EQ(point_str.str(), state_str.str());
+}
+
+TEST(TestCartesianState, RosMessageInitializationYieldsNormalizedQuaternions)
+{
+  cartesian_control_msgs::CartesianTrajectoryPoint init;
+  auto c = CartesianState(init);
+  EXPECT_DOUBLE_EQ(1.0, c.q.norm());
+}
+
+TEST(TestCartesianState, ConversionReturnsInitializingArgument)
+{
+  // Fill some fields with random values.
+  // Note that jerk, posture and time_from_start do not have a representation
+  // in CartesianState.
+
+  cartesian_control_msgs::CartesianTrajectoryPoint init;
+  init.acceleration.angular.x = 1.2345;
+  init.acceleration.linear.y = -173.47;
+  init.pose.orientation.w = 1;
+  init.pose.position.z = 0.003;
+  init.twist.linear.x = 67.594;
+
+  CartesianState state(init);
+  std::stringstream init_str;
+  std::stringstream state_str;
+  init_str << init;
+  state_str << state.toMsg();
+
+  EXPECT_EQ(init_str.str(), state_str.str());
+}
+
+TEST(CartesianState, RotationDifferenceIsPlausible)
+{
+  // Subtraction from zero yields the negative argument
+  CartesianState a;
+  CartesianState b;
+  b.p[0] = 1;
+  b.v[0] = 1;
+  b.w[0] = 1;
+  b.v_dot[0] = 1;
+  b.w_dot[0] = 1;
+
+  auto diff = a - b;
+  EXPECT_DOUBLE_EQ(-b.p[0], diff.p[0]);
+  EXPECT_DOUBLE_EQ(-b.v[0], diff.v[0]);
+  EXPECT_DOUBLE_EQ(-b.w[0], diff.w[0]);
+  EXPECT_DOUBLE_EQ(-b.v_dot[0], diff.v_dot[0]);
+  EXPECT_DOUBLE_EQ(-b.w_dot[0], diff.w_dot[0]);
+
+  // Rotations of 180 deg around single axis will have vanishing
+  // difference (singularity).
+  a.q.x() = 1;
+  EXPECT_DOUBLE_EQ(0.0, diff.rot().norm());
+  b.q.x() = 1;
+  EXPECT_DOUBLE_EQ(0.0, diff.rot().norm());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
@@ -125,7 +125,6 @@ TEST(TestCartesianState, ConversionReturnsInitializingArgument)
 
 TEST(CartesianState, RotationDifferenceIsPlausible)
 {
-  // Subtraction from zero yields the negative argument
   CartesianState a;
   CartesianState b;
   b.p[0] = 1;
@@ -134,6 +133,7 @@ TEST(CartesianState, RotationDifferenceIsPlausible)
   b.v_dot[0] = 1;
   b.w_dot[0] = 1;
 
+  // Subtraction from zero yields the negative argument
   auto diff = a - b;
   EXPECT_DOUBLE_EQ(-b.p[0], diff.p[0]);
   EXPECT_DOUBLE_EQ(-b.v[0], diff.v[0]);

--- a/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
@@ -103,7 +103,7 @@ TEST(TestCartesianState, RosMessageInitializationYieldsNormalizedQuaternions)
 
 TEST(TestCartesianState, ConversionReturnsInitializingArgument)
 {
-  // Fill some fields with random values.
+  // Fill some fields with arbitrary values.
   // Note that jerk, posture and time_from_start do not have a representation
   // in CartesianState and are therefore initialized to 0 (by default) in order to make their string representations to be expected the same..
 

--- a/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
@@ -105,7 +105,7 @@ TEST(TestCartesianState, ConversionReturnsInitializingArgument)
 {
   // Fill some fields with random values.
   // Note that jerk, posture and time_from_start do not have a representation
-  // in CartesianState.
+  // in CartesianState and are therefore initialized to 0 (by default) in order to make their string representations to be expected the same..
 
   cartesian_control_msgs::CartesianTrajectoryPoint init;
   init.acceleration.angular.x = 1.2345;

--- a/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_state_test.cpp
@@ -58,10 +58,6 @@ TEST(TestCartesianState, EmptyStateIsZeroInitialized)  // except for quaternion 
     EXPECT_EQ(state.w[i], 0);
     EXPECT_EQ(state.w_dot[i], 0);
   }
-  EXPECT_EQ(state.q.x(), 0);
-  EXPECT_EQ(state.q.y(), 0);
-  EXPECT_EQ(state.q.z(), 0);
-  EXPECT_EQ(state.q.w(), 1);
 }
 
 TEST(TestCartesianState, EmptyStateHasNormalizedQuaternion)

--- a/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    cartesian_trajectory_segment_test.cpp
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/25
+ *
+ */
+//-----------------------------------------------------------------------------
+
+
+#include <gtest/gtest.h>
+
+#include <cartesian_trajectory_interpolation/cartesian_trajectory_segment.h>
+
+using namespace cartesian_ros_control;
+
+TEST(TestCartesianTrajectorySegment, SamplingBeyondBoundariesIsSafe)
+{
+  CartesianState start;
+  start.p.x() = 1.0;
+  start.v.x() = 1.0;
+  start.w.x() = 1.0;
+  start.v_dot.x() = 1.0;
+  start.w_dot.x() = 1.0;
+  double start_time = 0;
+
+  CartesianState end;
+  end.p.x() = 2.0;
+  end.v.x() = 2.0;
+  end.w.x() = 2.0;
+  end.v_dot.x() = 2.0;
+  end.w_dot.x() = 2.0;
+  double end_time = 5.0;
+
+  CartesianTrajectorySegment seg{start_time, start, end_time, end};
+
+  // Sampling beyond the time boundaries should yield the boundary states with
+  // zero velocities and zero accelerations.
+
+  CartesianState sample_lower;
+  seg.sample(-1.0, sample_lower);
+
+  EXPECT_DOUBLE_EQ(start.p.x(), sample_lower.p.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.v.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.w.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.v_dot.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.w_dot.x());
+
+  CartesianState sample_upper;
+  seg.sample(6.0, sample_lower);
+
+  EXPECT_DOUBLE_EQ(end.p.x(), sample_lower.p.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.v.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.w.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.v_dot.x());
+  EXPECT_DOUBLE_EQ(0, sample_lower.w_dot.x());
+
+}
+
+TEST(TestCartesianTrajectorySegment, DoubleConversionIsIdentity)
+{
+  CartesianState c;
+
+  c.v.x() = 1.1;
+  c.v.y() = 1.2;
+  c.v.z() = 1.3;
+
+  c.w.x() = 2.1;
+  c.w.y() = 2.2;
+  c.w.z() = 2.3;
+
+  c.v_dot.x() = 3.1;
+  c.v_dot.y() = 3.2;
+  c.v_dot.z() = 3.3;
+
+  c.w_dot.x() = 4.1;
+  c.w_dot.y() = 4.2;
+  c.w_dot.z() = 4.3;
+
+  std::stringstream before;
+  std::stringstream after;
+  before << c;
+  after << convert(convert(c));
+
+  // Compact check if both `read` the same.
+  EXPECT_EQ(before.str(), after.str());
+}
+
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cartesian_trajectory_interpolation/test/cartesian_trajectory_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_trajectory_test.cpp
@@ -111,6 +111,44 @@ TEST(TestCartesianTrajectory, NonIncreasingWaypointsInTimeFail)
   EXPECT_FALSE(c_traj.init(init));
 }
 
+TEST(TestCartesianTrajectory, InterpolationGivesPlausibleResults)
+{
+  auto p1 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  p1.pose.position.x = 0.0;
+  p1.pose.position.y = 0.0;
+  p1.pose.position.z = 0.0;
+  p1.pose.orientation.x = 0;
+  p1.pose.orientation.y = 0;
+  p1.pose.orientation.z = 0;
+  p1.pose.orientation.w = 1;
+  p1.time_from_start = ros::Duration(0.0);
+
+  auto p2 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  p2.pose.position.x = 1.1;
+  p2.pose.position.y = 2.2;
+  p2.pose.position.z = 3.3;
+  p2.pose.orientation.x = 1; // 180 degrees around x
+  p2.pose.orientation.y = 0;
+  p2.pose.orientation.z = 0;
+  p2.pose.orientation.w = 0;
+  p2.time_from_start = ros::Duration(10.0);
+
+  cartesian_control_msgs::CartesianTrajectory traj;
+  traj.points.push_back(p1);
+  traj.points.push_back(p2);
+
+  auto c_traj = CartesianTrajectory(traj);
+  CartesianState c;
+  c_traj.sample(5, c);
+
+  constexpr double pi = 3.14159265358979323846;
+
+  // For the linear case, half the time should give half the values.
+  EXPECT_DOUBLE_EQ(p2.pose.position.x / 2.0, c.p.x());
+  EXPECT_DOUBLE_EQ(p2.pose.position.y / 2.0, c.p.y());
+  EXPECT_DOUBLE_EQ(p2.pose.position.z / 2.0, c.p.z());
+  EXPECT_DOUBLE_EQ(pi / 2.0, c.rot().norm());
+}
 
 int main(int argc, char** argv)
 {

--- a/cartesian_trajectory_interpolation/test/cartesian_trajectory_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_trajectory_test.cpp
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2021 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    cartesian_trajectory_test.cpp
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \date    2021/05/25
+ *
+ */
+//-----------------------------------------------------------------------------
+
+
+#include <gtest/gtest.h>
+
+#include <cartesian_trajectory_interpolation/cartesian_trajectory.h>
+#include <cartesian_trajectory_interpolation/cartesian_state.h>
+#include <cartesian_control_msgs/CartesianTrajectory.h>
+#include "Eigen/src/Core/Matrix.h"
+#include "cartesian_control_msgs/CartesianTrajectoryPoint.h"
+#include "ros/duration.h"
+#include <ros/ros.h>
+#include <ostream>
+
+using namespace cartesian_ros_control;
+
+TEST(TestCartesianTrajectory, SamplingFromEmptyTrajectoryGivesEmptyState)
+{
+  CartesianState a;
+  CartesianState b;
+
+  CartesianTrajectory empty_traj;
+  empty_traj.sample(-0.5, a);
+
+  std::stringstream a_str;
+  std::stringstream b_str;
+  a_str << a;
+  b_str << b;
+
+  EXPECT_EQ(b_str.str(), a_str.str());
+}
+
+TEST(TestCartesianTrajectory, DefaultQuaternionsGiveValidInterpolation)
+{
+  auto p1 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  p1.pose.position.x = 0.0;
+  p1.pose.position.y = 0.0;
+  p1.pose.position.z = 0.0;
+  p1.time_from_start = ros::Duration(0.0);
+
+  auto p2 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  p2.pose.position.x = 1.0;
+  p2.pose.position.y = 1.0;
+  p2.pose.position.z = 1.0;
+  p2.time_from_start = ros::Duration(5.0);
+
+  cartesian_control_msgs::CartesianTrajectory traj;
+  traj.points.push_back(p1);
+  traj.points.push_back(p2);
+
+  auto c_traj = CartesianTrajectory(traj);
+  CartesianState c;
+  c_traj.sample(2.5, c);
+
+  std::stringstream result;
+  result << c;
+
+  // Check for nan values as a frequent result for invalid, all-zero quaternion operations.
+  EXPECT_EQ(std::string::npos, result.str().find("nan"));
+}
+
+TEST(TestCartesianTrajectory, NonIncreasingWaypointsInTimeFail)
+{
+  auto p1 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  auto p2 = cartesian_control_msgs::CartesianTrajectoryPoint();
+  p1.time_from_start = ros::Duration(1.0);
+  p2.time_from_start = ros::Duration(0.9);
+
+  cartesian_control_msgs::CartesianTrajectory init;
+  init.points.push_back(p1);
+  init.points.push_back(p2);
+
+  CartesianTrajectory c_traj;
+  EXPECT_FALSE(c_traj.init(init));
+}
+
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add unit tests for the cartesian_trajectory_interpolation.
This also fixes some possible pitfalls when using this library and fixes a bug in the conversion between spline and Cartesian representation.