### PR TITLE
Tolerance check should check against given tolerance

### DIFF
--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -255,12 +255,12 @@ namespace trajectory_controllers {
     {
       // TODO: Velocity and acceleration limits will be affected by speed scaling.
       // Address this once we know more edge cases during beta testing.
-      if ((path_tolerances_[i].position > 0.0 &&
-           std::abs(error.positions[i]) > path_tolerances_[i].position) ||
-          (path_tolerances_[i].velocity > 0.0 &&
-           std::abs(error.velocities[i]) > path_tolerances_[i].velocity) ||
-          (path_tolerances_[i].acceleration > 0.0 &&
-           std::abs(error.accelerations[i]) > path_tolerances_[i].acceleration))
+      if ((tolerances[i].position > 0.0 &&
+           std::abs(error.positions[i]) > tolerances[i].position) ||
+          (tolerances[i].velocity > 0.0 &&
+           std::abs(error.velocities[i]) > tolerances[i].velocity) ||
+          (tolerances[i].acceleration > 0.0 &&
+           std::abs(error.accelerations[i]) > tolerances[i].acceleration))
       {
         return false;
       }


### PR DESCRIPTION
Before, it was always checking against path tolerance potentially leading
to a segfault, if only a goal tolerance is given