### PR TITLE
Fix tolerance handling for joint-based forwarding

### DIFF
--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
@@ -218,11 +218,13 @@ private:
    *
    * @param error The error to check
    * @param tolerances The tolerances to check against
+   * @param error_msg Additional information when tolerance check fails
    *
    * @return False if any of the errors exceeds its tolerance, else true
    */
   bool withinTolerances(const typename Base::TrajectoryPoint& error,
-                        const typename Base::Tolerance& tolerances);
+                        const typename Base::Tolerance& tolerances,
+                        std::string& error_msg);
 
   /**
    * @brief Check if follow trajectory goals are valid

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -266,7 +266,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.velocities[i]) <= tolerances[i].velocity;
         }
-        msg = "Velocity tolerances not fully supported by the driver implementation.";
+        msg = "Velocity tolerances specified, but not fully supported by the driver implementation.";
         return false;
       }
 

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -243,28 +243,40 @@ namespace trajectory_controllers {
     const TrajectoryPoint& error,
     const Tolerance& tolerances)
   {
-    // Precondition
-    if (!tolerances.empty())
-    {
-      assert(error.positions.size() == tolerances.size() &&
-          error.velocities.size() == tolerances.size() &&
-          error.accelerations.size() == tolerances.size());
-    }
-
+    // Check each user-given tolerance field individually.
+    // Fail if either the tolerance is exceeded or if the robot driver does not
+    // provide semantically correct data (conservative fail).
     for (size_t i = 0; i < tolerances.size(); ++i)
     {
-      // TODO: Velocity and acceleration limits will be affected by speed scaling.
-      // Address this once we know more edge cases during beta testing.
-      if ((tolerances[i].position > 0.0 &&
-           std::abs(error.positions[i]) > tolerances[i].position) ||
-          (tolerances[i].velocity > 0.0 &&
-           std::abs(error.velocities[i]) > tolerances[i].velocity) ||
-          (tolerances[i].acceleration > 0.0 &&
-           std::abs(error.accelerations[i]) > tolerances[i].acceleration))
+      if (tolerances[i].position > 0.0)
       {
-        return false;
+        if (error.positions.size() == tolerances.size())
+        {
+          return std::abs(error.positions[i]) <= tolerances[i].position;
+        }
+        else return false;
+      }
+
+      if (tolerances[i].velocity > 0.0)
+      {
+        if (error.velocities.size() == tolerances.size())
+        {
+          return std::abs(error.velocities[i]) <= tolerances[i].velocity;
+        }
+        else return false;
+      }
+
+      if (tolerances[i].acceleration > 0.0)
+      {
+        if (error.accelerations.size() == tolerances.size())
+        {
+          return std::abs(error.accelerations[i]) <= tolerances[i].acceleration;
+        }
+        else return false;
       }
     }
+
+    // Every error is ok for uninitialized tolerances
     return true;
   }
 

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -272,7 +272,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.accelerations[i]) <= tolerances[i].acceleration;
         }
-        else return false;
+        return false;
       }
     }
 

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -254,7 +254,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.positions[i]) <= tolerances[i].position;
         }
-        else return false;
+        return false;
       }
 
       if (tolerances[i].velocity > 0.0)

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -263,7 +263,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.velocities[i]) <= tolerances[i].velocity;
         }
-        else return false;
+        return false;
       }
 
       if (tolerances[i].acceleration > 0.0)

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -276,7 +276,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.accelerations[i]) <= tolerances[i].acceleration;
         }
-        msg = "Acceleration tolerances not fully supported by the driver implementation.";
+        msg = "Acceleration tolerances  specified, but not fully supported by the driver implementation.";
         return false;
       }
     }

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -256,7 +256,7 @@ namespace trajectory_controllers {
         {
           return std::abs(error.positions[i]) <= tolerances[i].position;
         }
-        msg = "Position tolerances not fully supported by the driver implementation.";
+        msg = "Position tolerances specified, but not fully supported by the driver implementation.";
         return false;
       }
 


### PR DESCRIPTION
This changes the joint-based tolerance checking:

- Check each user-given tolerance field individually.
- Fail if either the tolerance is exceeded or if the robot driver does not provide semantically correct data (conservative fail).

Fixes #18 