### PR TITLE
Reorder joint names for joint-based trajectories

### DIFF
--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -190,7 +190,14 @@ namespace trajectory_controllers {
     goal_tolerances_ = goal->goal_tolerance;
     
     // Notify the  vendor robot control.
-    trajectory_handle_->setCommand(*goal);
+    if (!trajectory_handle_->setCommand(*goal))
+    {
+      ROS_ERROR("Trajectory goal is invalid.");
+      typename Base::FollowTrajectoryResult result;
+      result.error_code = Base::FollowTrajectoryResult::INVALID_GOAL;
+      action_server_->setAborted(result);
+      return;
+    }
 
     // Time keeping
     action_duration_.current = ros::Duration(0.0);

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -44,6 +44,7 @@
 #include <functional>
 #include <hardware_interface/internal/hardware_resource_manager.h>
 #include <cartesian_control_msgs/FollowCartesianTrajectoryGoal.h>
+#include <cartesian_control_msgs/FollowCartesianTrajectoryResult.h>
 #include <cartesian_control_msgs/FollowCartesianTrajectoryFeedback.h>
 #include <control_msgs/FollowJointTrajectoryGoal.h>
 #include <control_msgs/FollowJointTrajectoryFeedback.h>
@@ -150,8 +151,9 @@ class TrajectoryHandle
      * joint resource list.
      *
      * @param command The new trajectory
+     * @return True if command is feasible, false otherwise
      */
-    void setCommand(TrajectoryType command);
+    bool setCommand(TrajectoryType command);
 
     /**
      * @brief Read a trajectory from the command buffer
@@ -233,7 +235,7 @@ class TrajectoryHandle
 
 // Full spezialization for JointTrajectory
 template<> inline
-void TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(JointTrajectory command)
+bool TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(JointTrajectory command)
 {
   control_msgs::FollowJointTrajectoryGoal tmp;
 
@@ -246,7 +248,7 @@ void TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(Join
   {
     // msg must contain all joint names.
     ROS_WARN("Not forwarding trajectory. It contains wrong number of joints");
-    return;
+    return false;
   }
   for (auto msg_it = msg.begin(); msg_it != msg.end(); ++msg_it)
   {
@@ -254,7 +256,7 @@ void TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(Join
     if (expected.end() == expected_it)
     {
       ROS_WARN_STREAM("Not forwarding trajectory. It contains at least one unexpected joint name: " << *msg_it);
-      return;
+      return false;
     }
     else
     {
@@ -294,13 +296,13 @@ void TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(Join
   {
     cmd_callback_(*cmd_);
   }
-
+  return true;
 }
 
 
 // Full spezialization for CartesianTrajectory
 template<> inline
-void TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::setCommand(CartesianTrajectory command)
+bool TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::setCommand(CartesianTrajectory command)
 {
   assert(cmd_);
   *cmd_ = command;
@@ -309,6 +311,7 @@ void TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::setComm
   {
     cmd_callback_(*cmd_);
   }
+  return true;
 }
 
 // Full spezializations for name deduction

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -146,18 +146,12 @@ class TrajectoryHandle
      * This will mainly be used by PassThroughControllers to store their new
      * incoming trajectories in the robot hardware interface.
      *
+     * Note: The JointTrajectory type reorders the joints according to the given
+     * joint resource list.
+     *
      * @param command The new trajectory
      */
-    void setCommand(TrajectoryType command)
-    {
-      assert(cmd_);
-      *cmd_ = command;
-
-      if (cmd_callback_)
-      {
-        cmd_callback_(*cmd_);
-      }
-    }
+    void setCommand(TrajectoryType command);
 
     /**
      * @brief Read a trajectory from the command buffer
@@ -214,13 +208,108 @@ class TrajectoryHandle
      */
     static std::string getName() noexcept;
 
+    /**
+     * @brief Set the order of joint names for trajectory reordering.
+     *
+     * @param joint_names
+     */
+    void setJointNames(const std::vector<std::string>& joint_names) noexcept {joint_names_ = joint_names;}
+
+    /**
+     * @brief Get the joint names associated with this handle
+     *
+     * @return Joint names
+     */
+    std::vector<std::string> getJointNames() const {return joint_names_;}
+
   private:
     TrajectoryType* cmd_;
     FeedbackType* feedback_;
     std::function<void(const TrajectoryType&)> cmd_callback_;
     std::function<void()> cancel_callback_;;
+    std::vector<std::string> joint_names_;
 };
 
+
+// Full spezialization for JointTrajectory
+template<> inline
+void TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(JointTrajectory command)
+{
+  control_msgs::FollowJointTrajectoryGoal tmp;
+
+  // Respect joint order by computing the map between msg indices to expected indices.
+  // If msg is {A, C, D, B} and expected is {A, B, C, D}, the associated mapping vector is {0, 2, 3, 1}
+  auto msg = command.trajectory.joint_names;
+  auto expected = joint_names_;
+  std::vector<size_t> msg_joints(msg.size());
+  if (msg.size() != expected.size())
+  {
+    // msg must contain all joint names.
+    ROS_WARN("Not forwarding trajectory. It contains wrong number of joints");
+    return;
+  }
+  for (auto msg_it = msg.begin(); msg_it != msg.end(); ++msg_it)
+  {
+    auto expected_it = std::find(expected.begin(), expected.end(), *msg_it);
+    if (expected.end() == expected_it)
+    {
+      ROS_WARN_STREAM("Not forwarding trajectory. It contains at least one unexpected joint name: " << *msg_it);
+      return;
+    }
+    else
+    {
+      const size_t msg_dist = std::distance(msg.begin(), msg_it);
+      const size_t expected_dist = std::distance(expected.begin(), expected_it);
+      msg_joints[msg_dist] = expected_dist;
+    }
+  }
+
+  // Reorder the joint names and data fields in all trajectory points
+  tmp.trajectory.joint_names = expected;
+
+  for (auto point : command.trajectory.points)
+  {
+    trajectory_msgs::JointTrajectoryPoint p{point};  // init for equal data size
+
+    for (size_t i = 0; i < expected.size(); ++i)
+    {
+      auto jnt_id = msg_joints[i];
+
+      if (point.positions.size() == expected.size())
+        p.positions[jnt_id] = point.positions[i];
+      if (point.velocities.size() == expected.size())
+        p.velocities[jnt_id] = point.velocities[i];
+      if (point.accelerations.size() == expected.size())
+        p.accelerations[jnt_id] = point.accelerations[i];
+      if (point.effort.size() == expected.size())
+        p.effort[jnt_id] = point.effort[i];
+    }
+    tmp.trajectory.points.push_back(p);
+  }
+
+  assert(cmd_);
+  *cmd_ = tmp;
+
+  if (cmd_callback_)
+  {
+    cmd_callback_(*cmd_);
+  }
+
+}
+
+
+// Full spezialization for CartesianTrajectory
+template<> inline
+void TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::setCommand(CartesianTrajectory command)
+{
+  assert(cmd_);
+  *cmd_ = command;
+
+  if (cmd_callback_)
+  {
+    cmd_callback_(*cmd_);
+  }
+}
 
 // Full spezializations for name deduction
 template<> inline
@@ -260,7 +349,7 @@ class TrajectoryInterface
     /**
      * @brief Associate resources with this interface
      *
-     * Call this during initialization of your controller.
+     * Call this right after initialization.
      * \Note: Proper resource handling depends on calling this
      * method \a before acquiring handles to this interface via getHandle().
      *
@@ -289,8 +378,42 @@ class TrajectoryInterface
       }
     }
 
+    /**
+     * @brief Specialized override for joint trajectory handles
+     *
+     * This passes the resource names associated with this interface to the
+     * returned JointTrajectoryHandle, which can then make use of them for
+     * reordering the incoming joint trajectories.
+     *
+     * In the case of CartesianTrajectoryHandle, this forwards the call
+     * to \a getHandle from HardwareResourceManager.
+     *
+     * @param name Name of trajectory handle
+     *
+     * @return Trajectory handle associated to \e name.
+     */
+    TrajectoryHandle<TrajectoryType, FeedbackType> getHandle(const std::string& name);
+    
+
   private:
     std::vector<std::string> joint_names_;
+};
+
+template<> inline
+JointTrajectoryHandle TrajectoryInterface<JointTrajectory, JointTrajectoryFeedback>::getHandle(const std::string& name)
+{
+  JointTrajectoryHandle joint_handle = this->hardware_interface::HardwareResourceManager<
+    JointTrajectoryHandle, hardware_interface::ClaimResources>::getHandle(name);
+
+  joint_handle.setJointNames(joint_names_);
+  return joint_handle;
+};
+
+template<> inline
+CartesianTrajectoryHandle TrajectoryInterface<CartesianTrajectory, CartesianTrajectoryFeedback>::getHandle(const std::string& name)
+{
+  return this->hardware_interface::HardwareResourceManager<
+    CartesianTrajectoryHandle, hardware_interface::ClaimResources>::getHandle(name);
 };
 
 /**

--- a/pass_through_controllers/test/launch/hw_interface.launch
+++ b/pass_through_controllers/test/launch/hw_interface.launch
@@ -1,4 +1,9 @@
 <launch>
+        <!-- Configuration -->
+        <arg name="debug" default="false"/>
+        <arg if="$(arg debug)" name="launch-prefix" value="screen -d -m gdb -command=$(env HOME)/.ros/my_debug_log --ex run --args"/>
+        <arg unless="$(arg debug)" name="launch-prefix" value=""/>
+
         <group ns="hw_interface">
 
                 <!-- Robot_description -->
@@ -15,7 +20,7 @@
                 <remap from="cartesian_trajectory_controller/follow_cartesian_trajectory"
                         to="/robot/cartesian_trajectory_controller/follow_cartesian_trajectory"/>
 
-                <node name="control_node" pkg="pass_through_controllers" type="hw_interface_example" output="screen"/>
+                <node name="control_node" pkg="pass_through_controllers" type="hw_interface_example" output="screen" launch-prefix="$(arg launch-prefix)"/>
 
                 <!-- Available controllers -->
                 <rosparam file="$(find pass_through_controllers)/test/hw_interface/controllers.yaml" command="load"></rosparam>

--- a/pass_through_controllers/test/test_forward_joint_trajectory.py
+++ b/pass_through_controllers/test/test_forward_joint_trajectory.py
@@ -98,6 +98,25 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(self.client.get_result().error_code,
                          FollowJointTrajectoryResult.SUCCESSFUL)
 
+    def test_wrong_joint_names(self):
+        """ Test whether a trajectory with wrong joint names fails """
+        self.switch_to_joint_control()
+
+        # Unknown joint names
+        joint_names = ['a', 'b', 'c', 'd', 'e', 'f']
+
+        start_joint_state = FollowJointTrajectoryGoal()
+        start_joint_state.trajectory.joint_names = joint_names
+
+        start_joint_state.trajectory.points = [
+            JointTrajectoryPoint(positions=self.joint_map.values(), time_from_start=rospy.Duration(3.0))]
+        self.client.send_goal(start_joint_state)
+        self.client.wait_for_result()
+
+        time.sleep(1)
+        self.assertEqual(self.client.get_result().error_code,
+                         FollowJointTrajectoryResult.INVALID_GOAL)
+
     def switch_to_joint_control(self):
         """ Assume possibly running Cartesian controllers"""
 

--- a/pass_through_controllers/test/test_forward_joint_trajectory.py
+++ b/pass_through_controllers/test/test_forward_joint_trajectory.py
@@ -6,6 +6,10 @@ import sys
 from control_msgs.msg import FollowJointTrajectoryAction, FollowJointTrajectoryGoal, FollowJointTrajectoryResult
 from trajectory_msgs.msg import JointTrajectoryPoint
 from controller_manager_msgs.srv import SwitchControllerRequest, SwitchController
+import tf
+import time
+import copy
+from collections import OrderedDict
 
 PKG = 'pass_through_controllers'
 NAME = 'test_joint_trajectory_forwarding'
@@ -41,10 +45,56 @@ class IntegrationTest(unittest.TestCase):
             self.fail(
                 "Could not reach hw_interface controller switch service. Msg: {}".format(err))
 
+        self.listener = tf.TransformListener()
+
+        # Correctly ordered joint names with reference joint state
+        self.joint_map = OrderedDict()
+        self.joint_map['joint1'] = 0
+        self.joint_map['joint2'] = -2.0
+        self.joint_map['joint3'] = 2.26
+        self.joint_map['joint4'] = -0.2513274122872
+        self.joint_map['joint5'] = 1.57
+        self.joint_map['joint6'] = 0.0
+
+        # Cartesian reference pose for this joint state (x,y,z, qx, qy, qz, qw)
+        self.p_ref = [0.354, 0.180, 0.390, 0.502, 0.502, 0.498, 0.498]
+
     def test_normal_execution(self):
-        """ Test the basic functionality by moving to a single joint state """
+        """ Test the basic functionality by moving to a defined joint state """
         self.switch_to_joint_control()
-        self.move()
+
+        # Move to reference joint state
+        start_joint_state = FollowJointTrajectoryGoal()
+        start_joint_state.trajectory.joint_names = self.joint_map.keys()
+
+        start_joint_state.trajectory.points = [
+            JointTrajectoryPoint(positions=self.joint_map.values(), time_from_start=rospy.Duration(3.0))]
+        self.client.send_goal(start_joint_state)
+        self.client.wait_for_result()
+
+        time.sleep(1)
+        self.check_reached()
+        self.assertEqual(self.client.get_result().error_code,
+                         FollowJointTrajectoryResult.SUCCESSFUL)
+
+    def test_mixed_joint_order(self):
+        """ Test whether a mixed-up joint order gets executed correctly """
+        self.switch_to_joint_control()
+
+        # Move to reference joint state with different joint order
+        joint_names = ['joint6', 'joint4', 'joint3', 'joint1', 'joint5', 'joint2']
+        q_start = [self.joint_map[i] for i in joint_names]
+
+        start_joint_state = FollowJointTrajectoryGoal()
+        start_joint_state.trajectory.joint_names = joint_names
+
+        start_joint_state.trajectory.points = [
+            JointTrajectoryPoint(positions=q_start, time_from_start=rospy.Duration(3.0))]
+        self.client.send_goal(start_joint_state)
+        self.client.wait_for_result()
+
+        time.sleep(1)
+        self.check_reached()
         self.assertEqual(self.client.get_result().error_code,
                          FollowJointTrajectoryResult.SUCCESSFUL)
 
@@ -65,23 +115,20 @@ class IntegrationTest(unittest.TestCase):
         srv.strictness = SwitchControllerRequest.BEST_EFFORT
         self.switch_forward_ctrl(srv)
 
-    def move(self):
-        """ Move to an arbitrary joint state within 3 seconds. """
-
-        q_start = [0, -2.0, 2.26, -0.2513274122872, 1.57, 0.0]  # From base to tip
-        start_joint_state = FollowJointTrajectoryGoal()
-        start_joint_state.trajectory.joint_names = [
-            'joint1',
-            'joint2',
-            'joint3',
-            'joint4',
-            'joint5',
-            'joint6']
-
-        start_joint_state.trajectory.points = [
-            JointTrajectoryPoint(positions=q_start, time_from_start=rospy.Duration(3.0))]
-        self.client.send_goal(start_joint_state)
-        self.client.wait_for_result()
+    def check_reached(self):
+        """ Check whether we reached our target within TF lookup accuracy """
+        try:
+            (trans, rot) = self.listener.lookupTransform('base_link', 'tool0', rospy.Time(0))
+        except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
+            pass
+        n = 3  # places accuracy
+        self.assertAlmostEqual(self.p_ref[0], trans[0], n)
+        self.assertAlmostEqual(self.p_ref[1], trans[1], n)
+        self.assertAlmostEqual(self.p_ref[2], trans[2], n)
+        self.assertAlmostEqual(self.p_ref[3], rot[0], n)
+        self.assertAlmostEqual(self.p_ref[4], rot[1], n)
+        self.assertAlmostEqual(self.p_ref[5], rot[2], n)
+        self.assertAlmostEqual(self.p_ref[6], rot[3], n)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Goal**:
MoveIt generates joint trajectories with alphabetic joint order.
This fix takes that into consideration and reorders the joints and
associated data fields in the joint trajectory message according to
a specified joint order.

These changes are best placed into the trajectory interface where a
type-based distinction is easier than in
PassThroughControllers.

Fixes #4 

**Possible next steps**:
There are two places where the joint names could be set for trajectory interfaces:

1) As currently done in the PassThroughControllers [here](https://github.com/fzi-forschungszentrum-informatik/cartesian_ros_control/blob/master/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp#L77) after the controller got the trajectory interface from the HW (just before getting a handle for writing commands).
The rational would be: _Users best known what joints their forwarding controller should operate on and in which order they are given. Different controllers can allow different joint combinations. There is no sanity check whether that's feasible with the driver_.


2) In the HWInterface, e.g. right after [this line](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/beta-testing/ur_robot_driver/src/hardware_interface.cpp#L340):
```c++
jnt_traj_interface_.setJointNames(joint_names_);
```
The rational would be: _Implementers of the driver best known what joints the trajectory interfaces will claim and in which order.  The forwarding controllers are valid for this specification. Users do not specify joints for them_.


With the second option, we then only have _one place_ where to specify the correct joint order: 
```yaml
# Settings for ros_control hardware interface
     ur_hardware_interface:
          joints: &robot_joints
             - shoulder_pan_joint
             - shoulder_lift_joint
             - elbow_joint
             - wrist_1_joint
             - wrist_2_joint
             - wrist_3_joint
```
(at least in theory. There seem to be various places in the ur*_controllers.yaml files :)
