### PR TITLE
Add mechanism to mark velocities/accelerations unspecified

### DIFF
--- a/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
+++ b/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
@@ -165,12 +165,12 @@ namespace cartesian_ros_control
    * given in the body-local reference frame that is implicitly defined
    * by \b state's pose. 
    *
-   * \note All-zero velocities and accelerations are interpreted as \a
-   * uninitialized and are mapped to \a empty spline velocities and
-   * accelerations, respectively. If zero values are intended as boundary
-   * conditions, then, at least one vanishingly small non-zero entry must be
-   * specified for one of the Cartesian dimensions, e.g. state.v.x() =
-   * 0.000001.
+   * \note By default, all-zero velocities and accelerations are interpreted as intended boundary conditions.
+   * If used together with Cartesian trajectory execution, this will yield
+   * smooth stops in the trajectory's waypoints (= cubic interpolation with
+   * zero velocity/acceleration boundary conditions).
+   * If users want linear interpolation, they should mark the velocities/accelerations as unspecified by setting
+   * at least one of the field values to NaN, e.g. state.v.x() = std::nan("0");
    *
    * @param state The CartesianState to convert
    *

--- a/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
+++ b/cartesian_trajectory_interpolation/include/cartesian_trajectory_interpolation/cartesian_trajectory_segment.h
@@ -101,7 +101,22 @@ namespace cartesian_ros_control
       virtual ~CartesianTrajectorySegment(){};
 
       /**
-       * @brief Construct a Cartesian trajectory segment from stat and end state.
+       * @brief Construct a Cartesian trajectory segment from start and end state.
+       *
+       * This uses the quintic spline interpolation from the joint_trajectory_controller under the hood.
+       * The Cartesian states are converted to spline states to fit into their pipeline.
+       * Here is the essential part of the documentation that also applies here:
+       *
+       * <BLOCKQUOTE>
+       * The start and end states need not necessarily be specified all the way to the acceleration level:
+       * - If only \b positions are specified, linear interpolation will be used.
+       * - If \b positions and \b velocities are specified, a cubic spline will be used.
+       * - If \b positions, \b velocities and \b accelerations are specified, a quintic spline will be used.
+       *
+       * \note If start and end states have different specifications
+       * (eg. start is positon-only, end is position-velocity), the lowest common specification will be used
+       * (position-only in the example).
+       * </BLOCKQUOTE>
        *
        * @param start_time Time in seconds when this segment starts
        * @param start_state CartesianState at start time
@@ -149,6 +164,13 @@ namespace cartesian_ros_control
    * \note SplineState has the velocities and accelerations
    * given in the body-local reference frame that is implicitly defined
    * by \b state's pose. 
+   *
+   * \note All-zero velocities and accelerations are interpreted as \a
+   * uninitialized and are mapped to \a empty spline velocities and
+   * accelerations, respectively. If zero values are intended as boundary
+   * conditions, then, at least one vanishingly small non-zero entry must be
+   * specified for one of the Cartesian dimensions, e.g. state.v.x() =
+   * 0.000001.
    *
    * @param state The CartesianState to convert
    *

--- a/cartesian_trajectory_interpolation/src/cartesian_trajectory_segment.cpp
+++ b/cartesian_trajectory_interpolation/src/cartesian_trajectory_segment.cpp
@@ -108,17 +108,9 @@ namespace cartesian_ros_control
     // Spline positions
     fill(spline_state.position, state.p, state.q);
 
-    // Obsolete after Eigen 3.4, which provides begin() and end() for Eigen vectors.
-    auto std = [](Eigen::Vector3d v){return std::vector<double>(v.data(), v.data() + v.size());};
-
-    // Check all vector fields for NaNs.
-    // Any occurence indicates a deliberately uninitialzed value.
-    auto uninitialized = [std](Eigen::Vector3d v)->bool{
-      return std::any_of(std(v).begin(), std(v).end(), [](double d){return std::isnan(d);});
-    };
-
     // Spline velocities
-    if (uninitialized(state.v) || uninitialized(state.w))
+    if(std::isnan(state.v.x()) || std::isnan(state.v.y()) || std::isnan(state.v.z())
+          || std::isnan(state.w.x()) || std::isnan(state.w.y()) || std::isnan(state.w.z()))
     {
       return spline_state;  // with uninitialized velocity/acceleration data
     }
@@ -130,7 +122,8 @@ namespace cartesian_ros_control
     fill(spline_state.velocity, state.q.inverse() * state.v, q_dot);
 
     // Spline accelerations
-    if (uninitialized(state.v_dot) || uninitialized(state.w_dot))
+    if(std::isnan(state.v_dot.x()) || std::isnan(state.v_dot.y()) || std::isnan(state.v_dot.z())
+          || std::isnan(state.w_dot.x()) || std::isnan(state.w_dot.y()) || std::isnan(state.w_dot.z()))
     {
       return spline_state;  // with uninitialized acceleration data
     }
@@ -150,6 +143,10 @@ namespace cartesian_ros_control
     CartesianState state;
 
     // Cartesian positions
+    if (s.position.empty())
+    {
+      return state;  // with positions/velocities/accelerations zero initialized
+    }
     state.p = Eigen::Vector3d(s.position[0], s.position[1], s.position[2]);
     state.q = Eigen::Quaterniond(s.position[3], s.position[4], s.position[5], s.position[6]).normalized();
 

--- a/cartesian_trajectory_interpolation/src/cartesian_trajectory_segment.cpp
+++ b/cartesian_trajectory_interpolation/src/cartesian_trajectory_segment.cpp
@@ -105,6 +105,11 @@ namespace cartesian_ros_control
     fill(spline_state.position, state.p, state.q);
 
     // Spline velocities
+    if (state.v == Eigen::Vector3d::Zero() && state.w == Eigen::Vector3d::Zero())
+    {
+      // All-zero velocities are interpreted as `deliberately not specified by the user`.
+      return spline_state;
+    }
     Eigen::Quaterniond q_dot;
     Eigen::Vector3d tmp = state.q.inverse() * state.w;
     Eigen::Quaterniond omega(0, tmp.x(), tmp.y(), tmp.z());
@@ -113,6 +118,11 @@ namespace cartesian_ros_control
     fill(spline_state.velocity, state.q.inverse() * state.v, q_dot);
 
     // Spline accelerations
+    if (state.v_dot == Eigen::Vector3d::Zero() && state.w_dot == Eigen::Vector3d::Zero())
+    {
+      // All-zero accelerations are interpreted as `deliberately not specified by the user`.
+      return spline_state;
+    }
     Eigen::Quaterniond q_ddot;
     tmp = state.q.inverse() * state.w_dot;
     Eigen::Quaterniond omega_dot(0, tmp.x(), tmp.y(), tmp.z());

--- a/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
@@ -126,15 +126,36 @@ TEST(TestCartesianTrajectorySegment, DoubleConversionIsIdentity)
   after << convert(convert(d));
   EXPECT_EQ(before.str(), after.str());
 
-  //--------------------------------------------------------------------------------
-  // Spline -> Cartesian -> Spline
-  //--------------------------------------------------------------------------------
+}
+
+TEST(TestCartesianTrajectorySegment, NansYieldEmptySplineVelocities)
+{
+  CartesianState c;
+  c.p.x() = 1.0;
+  c.p.y() = 2.0;
+  c.p.z() = 3.0;
+  c.q.w() = 4.0;
+  c.q.x() = 5.0;
+  c.q.y() = 6.0;
+  c.q.z() = 7.0;
+
+  c.v.x() = std::nan("0");
+
   CartesianTrajectorySegment::SplineState s;
-  before.clear();
-  after.clear();
-  before << s;
-  after << convert(convert(s));
-  EXPECT_EQ(before.str(), after.str());
+  s.position.push_back(1.0);
+  s.position.push_back(2.0);
+  s.position.push_back(3.0);
+  s.position.push_back(4.0);
+  s.position.push_back(5.0);
+  s.position.push_back(6.0);
+  s.position.push_back(7.0);
+  std::stringstream expected;
+  expected << s;
+
+  s = convert(c);
+  std::stringstream actual;
+  actual << s;
+  EXPECT_EQ(expected.str(), actual.str());
 }
 
 

--- a/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
+++ b/cartesian_trajectory_interpolation/test/cartesian_trajectory_segment_test.cpp
@@ -89,6 +89,9 @@ TEST(TestCartesianTrajectorySegment, SamplingBeyondBoundariesIsSafe)
 
 TEST(TestCartesianTrajectorySegment, DoubleConversionIsIdentity)
 {
+  //--------------------------------------------------------------------------------
+  // Cartesian -> Spline -> Cartesian
+  //--------------------------------------------------------------------------------
   CartesianState c;
 
   c.v.x() = 1.1;
@@ -113,6 +116,24 @@ TEST(TestCartesianTrajectorySegment, DoubleConversionIsIdentity)
   after << convert(convert(c));
 
   // Compact check if both `read` the same.
+  EXPECT_EQ(before.str(), after.str());
+
+  // The non-initialized case
+  CartesianState d;
+  before.clear();
+  after.clear();
+  before << d;
+  after << convert(convert(d));
+  EXPECT_EQ(before.str(), after.str());
+
+  //--------------------------------------------------------------------------------
+  // Spline -> Cartesian -> Spline
+  //--------------------------------------------------------------------------------
+  CartesianTrajectorySegment::SplineState s;
+  before.clear();
+  after.clear();
+  before << s;
+  after << convert(convert(s));
   EXPECT_EQ(before.str(), after.str());
 }
 


### PR DESCRIPTION
**Background**:
During trajectory execution with the _joint_trajectory_controller_, non-specified velocity and acceleration fields lead to [linear interpolation](https://github.com/ros-controls/ros_controllers/blob/noetic-devel/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h#L86).
The result is a trajectory execution without smooth stops in the waypoints by default (no boundary conditions given on vel/acc level).

The cartesian_trajectory_controller should continue this expected behavior. However, the default twist and accel ROS message fields can not remain _unspecified_ (because they are no array fields). They will be zero-initialized by default.
As a consequence, it's hard in the underlying quintic spline interpolation to differentiate, whether the all-zero values are defaults or _intended_ boundary conditions by the users.

**Approach**
This PR fixes this by interpreting all-zero velocity and acceleration values as uninitialized by default.
If zero values are intended as boundary conditions, then, at least one vanishingly small non-zero entry must be
specified for one of the twist/accel messages.

I personally think that's a sufficiently small overhead.

Here's an illustration in Python:
```python
from cartesian_control_msgs.msg import CartesianTrajectoryPoint

p = CartesianTrajectoryPoint()
p.pose.position.x = 0.354
p.pose.position.y = 0.180
p.pose.position.z = 0.390
p.pose.orientation.x = 0.502
p.pose.orientation.y = 0.502
p.pose.orientation.z = 0.498
p.pose.orientation.w = 0.498

# No stop in this waypoint by default
# p.twist.angular.z = 0.000001  # Will cause a smooth stop
```





A documentation for the cartesian_trajectory_controller will follow.