### PR TITLE
Switch done philosophy for trajectory forwarding

### DIFF
--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
@@ -62,6 +62,7 @@
 #include <actionlib/server/simple_action_server.h>
 #include <vector>
 #include <memory>
+#include <atomic>
 
 
 
@@ -236,11 +237,11 @@ private:
   bool isValid(const typename Base::GoalConstPtr& goal);
 
   /**
-   * @brief Call this when the action goal's time is up.
+   * @brief Should get called upon finishing the forwarded trajectory
    */
-  void timesUp();
+  void doneCB(const hardware_interface::ExecutionState& event);
 
-  bool done_;
+  std::atomic<bool> done_;
   ActionDuration action_duration_;
   std::unique_ptr<hardware_interface::SpeedScalingHandle> speed_scaling_;
   std::vector<std::string> joint_names_;

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
@@ -219,13 +219,11 @@ private:
    *
    * @param error The error to check
    * @param tolerances The tolerances to check against
-   * @param error_msg Additional information when tolerance check fails
    *
    * @return False if any of the errors exceeds its tolerance, else true
    */
   bool withinTolerances(const typename Base::TrajectoryPoint& error,
-                        const typename Base::Tolerance& tolerances,
-                        std::string& error_msg);
+                        const typename Base::Tolerance& tolerances);
 
   /**
    * @brief Check if follow trajectory goals are valid

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.h
@@ -74,7 +74,6 @@ struct JointBase
   using Tolerance              = std::vector<control_msgs::JointTolerance>;
   using TrajectoryPoint        = trajectory_msgs::JointTrajectoryPoint;
   using TrajectoryFeedback     = hardware_interface::JointTrajectoryFeedback; 
-  using TrajectoryHandle       = hardware_interface::JointTrajectoryHandle;
   using FollowTrajectoryAction = control_msgs::FollowJointTrajectoryAction;
   using FollowTrajectoryResult = control_msgs::FollowJointTrajectoryResult;
   using GoalConstPtr           = control_msgs::FollowJointTrajectoryGoalConstPtr;
@@ -85,7 +84,6 @@ struct CartesianBase
   using Tolerance              = cartesian_control_msgs::CartesianTolerance;
   using TrajectoryPoint        = cartesian_control_msgs::CartesianTrajectoryPoint;
   using TrajectoryFeedback     = hardware_interface::CartesianTrajectoryFeedback;
-  using TrajectoryHandle       = hardware_interface::CartesianTrajectoryHandle;
   using FollowTrajectoryAction = cartesian_control_msgs::FollowCartesianTrajectoryAction;
   using FollowTrajectoryResult = cartesian_control_msgs::FollowCartesianTrajectoryResult;
   using GoalConstPtr           = cartesian_control_msgs::FollowCartesianTrajectoryGoalConstPtr;
@@ -160,8 +158,7 @@ public:
   /**
    * @brief Callback method for new action goals
    *
-   * This method calls the \a on_new_cmd callback from the
-   * hardware_interface::TrajectoryHandle<JointTrajectory>.
+   * This method calls the \a setGoal() method from the TrajectoryInterface.
    * Implementers of the ROS-control HW can choose how the trajectory goal is
    * forwarded to the robot for interpolation.
    *
@@ -184,9 +181,9 @@ public:
    * directly upon a client request or indirectly when receiving a new goal
    * while another is still active.
    *
-   * This method calls the \a on_cancel callback from the hardware_interface::TrajectoryHandle<JointTrajectory>.
-   * Implementers of the ROS-control HW can implement how this notification is
-   * handled by the robot vendor control.
+   * This method calls the \a setCancel() method from the TrajectoryInterface.
+   * The RobotHW should implement how this notification is handled by the robot
+   * vendor control.
    *
    * Also check 
    * <a href="https://answers.ros.org/question/333316/actionlib-preempt-vs-cancel/">this info</a>.
@@ -235,9 +232,9 @@ private:
   bool isValid(const typename Base::GoalConstPtr& goal);
 
   /**
-   * @brief Should get called upon finishing the forwarded trajectory
+   * @brief Will get called upon finishing the forwarded trajectory
    */
-  void doneCB(const hardware_interface::ExecutionState& event);
+  void doneCB(const hardware_interface::ExecutionState& state);
 
   std::atomic<bool> done_;
   ActionDuration action_duration_;
@@ -245,7 +242,7 @@ private:
   std::vector<std::string> joint_names_;
   typename Base::Tolerance path_tolerances_;
   typename Base::Tolerance goal_tolerances_;
-  std::unique_ptr<typename Base::TrajectoryHandle> trajectory_handle_;
+  TrajectoryInterface* trajectory_interface_;  ///* Resource managed by RobotHW
   std::unique_ptr<actionlib::SimpleActionServer<typename Base::FollowTrajectoryAction> >
     action_server_;
 };

--- a/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
+++ b/pass_through_controllers/include/pass_through_controllers/pass_through_controllers.hpp
@@ -126,6 +126,12 @@ namespace trajectory_controllers {
     {
       // Stop trajectory interpolation on the robot
       trajectory_interface_->setCancel();
+
+      typename Base::FollowTrajectoryResult result;
+      result.error_string = "Controller stopped.";
+      result.error_code = Base::FollowTrajectoryResult::PATH_TOLERANCE_VIOLATED;
+      action_server_->setAborted(result);
+      done_ = true;
     }
 
   }
@@ -342,6 +348,11 @@ namespace trajectory_controllers {
   void PassThroughController<TrajectoryInterface>::doneCB(const hardware_interface::ExecutionState& state)
   {
     typename Base::FollowTrajectoryResult result;
+
+    if (!action_server_->isActive())
+    {
+      return;
+    }
 
     switch(state)
     {

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -53,13 +53,17 @@
 namespace hardware_interface {
 
 /**
- * @brief Hardware-specific done flags
+ * @brief Hardware-generic done flags for trajectory execution
+ *
+ * When forwarding trajectories to robots, we hand-over control of the actual
+ * execution.  This is a minimal set of generic flags to be reported by the
+ * hardware that PassThroughControllers can process and react upon.
  */
 enum class ExecutionState
 {
   SUCCESS = 0,
-  NOT_RESPONDING = -1,
-  GENERAL_ERROR = -2,
+  PREEMPTED = -1,
+  ABORTED = -2,
 };
 
 /**
@@ -228,6 +232,9 @@ class TrajectoryHandle
     /**
      * @brief Register a callback for the controller to react upon \a done signals from the hardware
      *
+     * Use this mechanism in the PassThroughController to bind to a member
+     * function for handling the ExecutionState of the forwarded trajectory.
+     *
      * @param std::function The function to be called by the ROS controller
      */
     void registerDoneCallback(std::function<void(const ExecutionState&)>){}
@@ -235,7 +242,11 @@ class TrajectoryHandle
     /**
      * @brief Mark the execution of a trajectory done.
      *
-     * @param state The final state
+     * Call this function when done with a forwarded trajectory in your
+     * RobotHW. The PassThroughController will implement a callback to 
+     * set appropriate result flags for the trajectory action clients.
+     *
+     * @param state The final state after trajectory execution
      */
     void setDone(const ExecutionState& state){if (done_callback_ != nullptr) done_callback_(state);}
 

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -154,7 +154,7 @@ class TrajectoryInterface : public hardware_interface::HardwareInterface
      *
      * @param f The function to be called when trajectory execution is done
      */
-    void registerDoneCallback(const std::function<void(const ExecutionState&)>& f)
+    void registerDoneCallback(std::function<void(const ExecutionState&)> f)
     {
       done_callback_ = f;
     }

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -262,7 +262,7 @@ class TrajectoryInterface : public hardware_interface::HardwareInterface
 template<> inline
 bool TrajectoryInterface<JointTrajectory, JointTrajectoryFeedback>::setGoal(JointTrajectory goal)
 {
-  control_msgs::FollowJointTrajectoryGoal tmp;
+  control_msgs::FollowJointTrajectoryGoal tmp = goal;
 
   // Respect joint order by computing the map between msg indices to expected indices.
   // If msg is {A, C, D, B} and expected is {A, B, C, D}, the associated mapping vector is {0, 2, 3, 1}
@@ -293,6 +293,7 @@ bool TrajectoryInterface<JointTrajectory, JointTrajectoryFeedback>::setGoal(Join
 
   // Reorder the joint names and data fields in all trajectory points
   tmp.trajectory.joint_names = expected;
+  tmp.trajectory.points.clear();
 
   for (auto point : goal.trajectory.points)
   {

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -53,6 +53,16 @@
 namespace hardware_interface {
 
 /**
+ * @brief Hardware-specific done flags
+ */
+enum class ExecutionState
+{
+  SUCCESS = 0,
+  NOT_RESPONDING = -1,
+  GENERAL_ERROR = -2,
+};
+
+/**
  * @brief TrajectoryType for joint-based trajectories
  */
 using JointTrajectory = control_msgs::FollowJointTrajectoryGoal;
@@ -71,8 +81,6 @@ using JointTrajectoryFeedback = control_msgs::FollowJointTrajectoryFeedback;
  * @brief FeedbackType for Cartesian trajectories
  */
 using CartesianTrajectoryFeedback = cartesian_control_msgs::FollowCartesianTrajectoryFeedback;
-
-
 
 /**
  * @brief A class implementing handles for trajectory hardware interfaces
@@ -218,6 +226,20 @@ class TrajectoryHandle
     void setJointNames(const std::vector<std::string>& joint_names) noexcept {joint_names_ = joint_names;}
 
     /**
+     * @brief Register a callback for the controller to react upon \a done signals from the hardware
+     *
+     * @param std::function The function to be called by the ROS controller
+     */
+    void registerDoneCallback(std::function<void(const ExecutionState&)>){}
+
+    /**
+     * @brief Mark the execution of a trajectory done.
+     *
+     * @param state The final state
+     */
+    void setDone(const ExecutionState& state){if (done_callback_ != nullptr) done_callback_(state);}
+
+    /**
      * @brief Get the joint names associated with this handle
      *
      * @return Joint names
@@ -229,6 +251,7 @@ class TrajectoryHandle
     FeedbackType* feedback_;
     std::function<void(const TrajectoryType&)> cmd_callback_;
     std::function<void()> cancel_callback_;;
+    std::function<void(const ExecutionState&)> done_callback_{nullptr};
     std::vector<std::string> joint_names_;
 };
 

--- a/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
+++ b/pass_through_controllers/include/pass_through_controllers/trajectory_interface.h
@@ -42,13 +42,14 @@
 #pragma once
 
 #include <functional>
-#include <hardware_interface/internal/hardware_resource_manager.h>
 #include <cartesian_control_msgs/FollowCartesianTrajectoryGoal.h>
 #include <cartesian_control_msgs/FollowCartesianTrajectoryResult.h>
 #include <cartesian_control_msgs/FollowCartesianTrajectoryFeedback.h>
 #include <control_msgs/FollowJointTrajectoryGoal.h>
 #include <control_msgs/FollowJointTrajectoryFeedback.h>
 #include <vector>
+#include <hardware_interface/hardware_interface.h>
+#include <ros/ros.h>
 
 namespace hardware_interface {
 
@@ -86,196 +87,186 @@ using JointTrajectoryFeedback = control_msgs::FollowJointTrajectoryFeedback;
  */
 using CartesianTrajectoryFeedback = cartesian_control_msgs::FollowCartesianTrajectoryFeedback;
 
+
+
 /**
- * @brief A class implementing handles for trajectory hardware interfaces
+ * @brief Hardware interface for forwarding trajectories
  *
- * This is a special type of interface handle for PassThroughControllers. The
- * handles provide read/write access to trajectory command buffers and
- * read/write access to trajectory feedback buffers.
+ * This special hardware interface is primarily used by PassThroughControllers,
+ * which forward full trajectories to robots for interpolation. In contrast to
+ * other hardware interfaces, this interface does not provide the usual handle
+ * mechanism.  Instead, callbacks and respective setter methods allow to
+ * implement control flow during trajectory execution.  Resources need to be
+ * claimed in the forwarding controller's constructor with \a setResources().
  *
- * @tparam TrajectoryType The type of trajectory used.
+ * The intended usage is as follows:
+ * - The RobotHW instantiates this TrajectoryInterface and registers callbacks
+ *   for forwarded goals and cancel requests with \a registerGoalCallback() and
+ *   \a registerCancelCallback(), respectively. 
+ * - On the controller side, the PassThroughController calls the respective \a
+ *   setGoal() and \a setCancel() methods to trigger those events for the
+ *   RobotHW. The PassThroughController also registers a callback for signals
+ *   from the RobotHW when trajectory execution is done with \a
+ *   registerDoneCallback().
+ * - When done with the trajectory execution, the RobotHW calls \a setDone() to
+ *   inform the PassThroughController via its registered callback.
+ * - The RobotHW gives feedback continuously from the execution with \a
+ *   setFeedback(), which is used by the PassThroughController via \a
+ *   getFeedback().
+ *
+ * @tparam TrajectoryType Distinguish between joint-based and Cartesian trajectories
  * @tparam FeedbackType The type of feedback for the trajectory used.
  */
-template<class TrajectoryType, class FeedbackType>
-class TrajectoryHandle
+template <class TrajectoryType, class FeedbackType>
+class TrajectoryInterface : public hardware_interface::HardwareInterface
 {
   public:
-    TrajectoryHandle() = delete;
 
     /**
-     * @brief A trajectory handle for managing read/write functionality for
-     * PassThroughControllers
+     * @brief Register a RobotHW-side callback for new trajectory execution
      *
-     * @param cmd The command buffer for read/write operations
-     * @param feedback The feedback buffer for read/write operations
+     * Callback for triggering execution start in the RobotHW.
+     * Use this callback mechanism to handle starting of
+     * trajectories on the robot vendor controller.
+     *
+     * @param f The function to be called for starting trajectory execution
      */
-    TrajectoryHandle(TrajectoryType* cmd, FeedbackType* feedback)
-      : cmd_(cmd)
-      , feedback_(feedback)
+    void registerGoalCallback(std::function<void(const TrajectoryType&)> f)
     {
-      if (!cmd || !feedback)
-      {
-        throw HardwareInterfaceException(
-          "Cannot create TrajectoryHandle. Make sure to provide both command and feedback buffers during construction");
-      }
-    };
+      goal_callback_ = f;
+    }
 
     /**
-     * @brief A trajectory handle for managing read/write functionality for
-     * PassThroughControllers
+     * @brief Register a RobotHW-side callback for canceling requests
      *
-     * Overload for using callbacks to trigger precise start and cancel events
-     * in user code. In the context of using PassThroughControllers,
-     * implementers of ROS-control HW-interfaces can use this callback
-     * mechanism to handle starting and canceling of trajectories on the robot
-     * vendor controller.
-     *
-     * @param cmd The command buffer for read/write operations
-     * @param feedback The feedback buffer for read/write operations
-     * @param on_new_cmd Callback that is called upon receiving new commands
-     * @param on_cancel Callback that is called when current commands are canceled
+     * @param f The function to be called for canceling trajectory execution
      */
-    TrajectoryHandle(TrajectoryType* cmd,
-                     FeedbackType* feedback,
-                     std::function<void(const TrajectoryType&)> on_new_cmd,
-                     std::function<void()> on_cancel)
-      : cmd_(cmd)
-      , feedback_(feedback)
-      , cmd_callback_(on_new_cmd)
-      , cancel_callback_(on_cancel)
+    void registerCancelCallback(std::function<void()> f)
     {
-      if (!cmd || !feedback)
-      {
-        throw HardwareInterfaceException(
-          "Cannot create TrajectoryHandle. Make sure to provide both command and feedback buffers during construction");
-      }
-    };
-
-    ~TrajectoryHandle(){};
+      cancel_callback_ = f;
+    }
 
     /**
-     * @brief Write the command buffer with the content of an new trajectory
+     * @brief Register a Controller-side callback for done signals from the hardware
      *
-     * This will mainly be used by PassThroughControllers to store their new
-     * incoming trajectories in the robot hardware interface.
+     * Use this mechanism in the PassThroughController for handling the
+     * ExecutionState of the forwarded trajectory.
      *
-     * Note: The JointTrajectory type reorders the joints according to the given
-     * joint resource list.
+     * @param f The function to be called when trajectory execution is done
+     */
+    void registerDoneCallback(const std::function<void(const ExecutionState&)>& f)
+    {
+      done_callback_ = f;
+    }
+
+    /**
+     * @brief Start the forwarding of new trajectories
+     *
+     * Controller-side method to send incoming trajectories to the RobotHW.
+     *
+     * Note: The JointTrajectory type reorders the joints according to the
+     * given joint resource list.
      *
      * @param command The new trajectory
-     * @return True if command is feasible, false otherwise
+     * @return True if goal is feasible, false otherwise
      */
-    bool setCommand(TrajectoryType command);
+    bool setGoal(TrajectoryType goal);
 
     /**
-     * @brief Read a trajectory from the command buffer
+     * @brief Cancel the current trajectory execution
      *
-     * This can be used to access content from forwarded trajectories in the
-     * robot hardware interface.
-     *
-     * @return The content of the trajectory command buffer
+     * Controller-side method to cancel current trajectory execution on the robot.
      */
-    TrajectoryType getCommand() const {assert(cmd_); return *cmd_;}
-
-    /**
-     * @brief Cancel an active command
-     */
-    void cancelCommand()
+    void setCancel()
     {
-      if (cancel_callback_)
-      {
-        cancel_callback_();
-      }
+      if (cancel_callback_ != nullptr) cancel_callback_();
+    };
+
+    /**
+     * @brief RobotHW-side method to mark the execution of a trajectory done.
+     *
+     * Call this function when done with a forwarded trajectory in your
+     * RobotHW or when unexpected interruptions occur. The
+     * PassThroughController will implement a callback to set appropriate
+     * result flags for the trajectory action clients.
+     *
+     * @param state The final state after trajectory execution
+     */
+    void setDone(const ExecutionState& state)
+    {
+      if (done_callback_ != nullptr) done_callback_(state);
     }
 
     /**
      * @brief Set trajectory feedback for PassThroughControllers
      *
-     * This should be used by the robot HW to provide feedback on trajectory
-     * execution for the PassThroughControllers
+     * This should be used by the RobotHW to provide continuous feedback on
+     * trajectory execution for the PassThroughControllers.
      *
      * @param feedback The feedback content to write to the interface
      */
     void setFeedback(FeedbackType feedback)
     {
-      assert(feedback_);
-      *feedback_ = feedback;
+      feedback_ = feedback;
     }
 
     /**
-     * @brief Access trajectory feedback
+     * @brief Get trajectory feedback
      *
-     * This can be used by PassThroughControllers to get trajectory feedback
-     * from the hardware interface.
+     * This can be used by PassThroughControllers to continuously poll
+     * trajectory feedback from the hardware interface.
      *
-     * @return The most recent feedback on the trajectory execution
+     * @return The most recent feedback on the current trajectory execution
      */
-    FeedbackType getFeedback() const {assert(feedback_); return *feedback_;}
+    FeedbackType getFeedback() const
+    {
+      return feedback_;
+    }
 
     /**
-     * @brief Get the name of this trajectory handle
-     *
-     * By convention, this either returns \a joint_trajectory_handle for joint-based trajectory handles
-     * and \a cartesian_trajectory_handle for Cartesian-based trajectory handles.
-     *
-     * @return The name that is associated with this specific handle
-     */
-    static std::string getName() noexcept;
-
-    /**
-     * @brief Set the order of joint names for trajectory reordering.
-     *
-     * @param joint_names
-     */
-    void setJointNames(const std::vector<std::string>& joint_names) noexcept {joint_names_ = joint_names;}
-
-    /**
-     * @brief Register a callback for the controller to react upon \a done signals from the hardware
-     *
-     * Use this mechanism in the PassThroughController to bind to a member
-     * function for handling the ExecutionState of the forwarded trajectory.
-     *
-     * @param std::function The function to be called by the ROS controller
-     */
-    void registerDoneCallback(std::function<void(const ExecutionState&)>){}
-
-    /**
-     * @brief Mark the execution of a trajectory done.
-     *
-     * Call this function when done with a forwarded trajectory in your
-     * RobotHW. The PassThroughController will implement a callback to 
-     * set appropriate result flags for the trajectory action clients.
-     *
-     * @param state The final state after trajectory execution
-     */
-    void setDone(const ExecutionState& state){if (done_callback_ != nullptr) done_callback_(state);}
-
-    /**
-     * @brief Get the joint names associated with this handle
+     * @brief Get the joint names (resources) associated with this interface.
      *
      * @return Joint names
      */
-    std::vector<std::string> getJointNames() const {return joint_names_;}
+    std::vector<std::string> getJointNames() const
+    {
+      return joint_names_;
+    }
+
+    /**
+     * @brief Associate resources with this interface
+     *
+     * \Note: Call this inside the PassThroughController's constructor to
+     * manage resource conflicts with other ROS controllers.
+     *
+     * @param resources A list of resource names
+     */
+    void setResources(std::vector<std::string> resources)
+    {
+      for (const std::string& joint : resources)
+      {
+        hardware_interface::HardwareInterface::claim(joint);
+      }
+      joint_names_ = resources;
+    }
 
   private:
-    TrajectoryType* cmd_;
-    FeedbackType* feedback_;
-    std::function<void(const TrajectoryType&)> cmd_callback_;
-    std::function<void()> cancel_callback_;;
-    std::function<void(const ExecutionState&)> done_callback_{nullptr};
+    std::function<void(const TrajectoryType&)> goal_callback_;
+    std::function<void()> cancel_callback_;
+    std::function<void(const ExecutionState&)> done_callback_;
+    FeedbackType feedback_;
     std::vector<std::string> joint_names_;
 };
 
-
 // Full spezialization for JointTrajectory
 template<> inline
-bool TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(JointTrajectory command)
+bool TrajectoryInterface<JointTrajectory, JointTrajectoryFeedback>::setGoal(JointTrajectory goal)
 {
   control_msgs::FollowJointTrajectoryGoal tmp;
 
   // Respect joint order by computing the map between msg indices to expected indices.
   // If msg is {A, C, D, B} and expected is {A, B, C, D}, the associated mapping vector is {0, 2, 3, 1}
-  auto msg = command.trajectory.joint_names;
+  auto msg = goal.trajectory.joint_names;
   auto expected = joint_names_;
   std::vector<size_t> msg_joints(msg.size());
   if (msg.size() != expected.size())
@@ -303,7 +294,7 @@ bool TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(Join
   // Reorder the joint names and data fields in all trajectory points
   tmp.trajectory.joint_names = expected;
 
-  for (auto point : command.trajectory.points)
+  for (auto point : goal.trajectory.points)
   {
     trajectory_msgs::JointTrajectoryPoint p{point};  // init for equal data size
 
@@ -323,135 +314,27 @@ bool TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::setCommand(Join
     tmp.trajectory.points.push_back(p);
   }
 
-  assert(cmd_);
-  *cmd_ = tmp;
-
-  if (cmd_callback_)
+  if (goal_callback_ != nullptr)
   {
-    cmd_callback_(*cmd_);
+    goal_callback_(tmp);
+    return true;
   }
-  return true;
+  return false;
 }
 
 
 // Full spezialization for CartesianTrajectory
 template<> inline
-bool TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::setCommand(CartesianTrajectory command)
+bool TrajectoryInterface<CartesianTrajectory, CartesianTrajectoryFeedback>::setGoal(CartesianTrajectory goal)
 {
-  assert(cmd_);
-  *cmd_ = command;
-
-  if (cmd_callback_)
+  if (goal_callback_ != nullptr)
   {
-    cmd_callback_(*cmd_);
+    goal_callback_(goal);
+    return true;
   }
-  return true;
+  return false;
 }
 
-// Full spezializations for name deduction
-template<> inline
-std::string TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>::getName() noexcept
-{
-  return "joint_trajectory_handle";
-};
-
-template<> inline
-std::string TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>::getName() noexcept
-{
-  return "cartesian_trajectory_handle";
-};
-
-using JointTrajectoryHandle = TrajectoryHandle<JointTrajectory, JointTrajectoryFeedback>;
-using CartesianTrajectoryHandle = TrajectoryHandle<CartesianTrajectory, CartesianTrajectoryFeedback>;
-
-
-/**
- * @brief Hardware interface for commanding trajectories
- *
- * This special hardware interface is primarily used by PassThroughControllers,
- * which forward full trajectories to robots for interpolation. In contrast to
- * other hardware interfaces, this interface claims multiple resources and
- * offers write access to full trajectory buffers.
- *
- * @tparam TrajectoryType Distinguish between joint-based and Cartesian trajectories
- * @tparam FeedbackType The type of feedback for the trajectory used.
- */
-template <class TrajectoryType, class FeedbackType>
-class TrajectoryInterface
-  : public hardware_interface::HardwareResourceManager<TrajectoryHandle<TrajectoryType, FeedbackType>,
-                                                       hardware_interface::ClaimResources>
-{
-  public:
-
-    /**
-     * @brief Associate resources with this interface
-     *
-     * Call this right after initialization.
-     * \Note: Proper resource handling depends on calling this
-     * method \a before acquiring handles to this interface via getHandle().
-     *
-     * @param resources A list of resource names
-     */
-    void setResources(std::vector<std::string> resources)
-    {
-      joint_names_ = resources;
-    }
-
-    /**
-     * @brief Claim multiple resources when using a single TrajectoryHandle
-     *
-     * This makes sure that PassThroughControllers claim all associated
-     * resources.
-     *
-     * @param std::string Not used
-     */
-    void claim(std::string /*resource*/) override
-    {
-      for (const std::string& joint : joint_names_)
-      {
-        hardware_interface::HardwareResourceManager<
-          TrajectoryHandle<TrajectoryType, FeedbackType>,
-          hardware_interface::ClaimResources>::claim(joint);
-      }
-    }
-
-    /**
-     * @brief Specialized override for joint trajectory handles
-     *
-     * This passes the resource names associated with this interface to the
-     * returned JointTrajectoryHandle, which can then make use of them for
-     * reordering the incoming joint trajectories.
-     *
-     * In the case of CartesianTrajectoryHandle, this forwards the call
-     * to \a getHandle from HardwareResourceManager.
-     *
-     * @param name Name of trajectory handle
-     *
-     * @return Trajectory handle associated to \e name.
-     */
-    TrajectoryHandle<TrajectoryType, FeedbackType> getHandle(const std::string& name);
-    
-
-  private:
-    std::vector<std::string> joint_names_;
-};
-
-template<> inline
-JointTrajectoryHandle TrajectoryInterface<JointTrajectory, JointTrajectoryFeedback>::getHandle(const std::string& name)
-{
-  JointTrajectoryHandle joint_handle = this->hardware_interface::HardwareResourceManager<
-    JointTrajectoryHandle, hardware_interface::ClaimResources>::getHandle(name);
-
-  joint_handle.setJointNames(joint_names_);
-  return joint_handle;
-};
-
-template<> inline
-CartesianTrajectoryHandle TrajectoryInterface<CartesianTrajectory, CartesianTrajectoryFeedback>::getHandle(const std::string& name)
-{
-  return this->hardware_interface::HardwareResourceManager<
-    CartesianTrajectoryHandle, hardware_interface::ClaimResources>::getHandle(name);
-};
 
 /**
  * @brief Hardware interface for commanding (forwarding) joint-based trajectories

--- a/pass_through_controllers/test/hw_interface/hw_interface.h
+++ b/pass_through_controllers/test/hw_interface/hw_interface.h
@@ -14,6 +14,8 @@
 #pragma once
 
 // ROS
+#include "cartesian_control_msgs/FollowCartesianTrajectoryResult.h"
+#include "control_msgs/FollowJointTrajectoryResult.h"
 #include "ros/publisher.h"
 #include "ros/subscriber.h"
 #include <ros/ros.h>
@@ -113,10 +115,6 @@ private:
   std::vector<double> pos_;
   std::vector<double> vel_;
   std::vector<double> eff_;
-  hardware_interface::JointTrajectory jnt_traj_cmd_;
-  hardware_interface::JointTrajectoryFeedback jnt_traj_feedback_;
-  hardware_interface::CartesianTrajectory cart_traj_cmd_;
-  hardware_interface::CartesianTrajectoryFeedback cart_traj_feedback_;
   double speed_scaling_;
   geometry_msgs::Pose pose_cmd_;
 
@@ -160,11 +158,17 @@ private:
     joint_based_communication_;
   void handleJointFeedback(const control_msgs::FollowJointTrajectoryFeedbackConstPtr& feedback);
 
+  void handleJointDone(const actionlib::SimpleClientGoalState& state,
+                       const control_msgs::FollowJointTrajectoryResultConstPtr& result);
+
   std::unique_ptr<
     actionlib::SimpleActionClient<cartesian_control_msgs::FollowCartesianTrajectoryAction> >
     cartesian_based_communication_;
   void handleCartesianFeedback(
     const cartesian_control_msgs::FollowCartesianTrajectoryFeedbackConstPtr& feedback);
+
+  void handleCartesianDone(const actionlib::SimpleClientGoalState& state,
+                           const cartesian_control_msgs::FollowCartesianTrajectoryResultConstPtr& result);
 };
 
 } // namespace examples

--- a/pass_through_controllers/test/test_forward_joint_trajectory.py
+++ b/pass_through_controllers/test/test_forward_joint_trajectory.py
@@ -69,6 +69,7 @@ class IntegrationTest(unittest.TestCase):
 
         start_joint_state.trajectory.points = [
             JointTrajectoryPoint(positions=self.joint_map.values(), time_from_start=rospy.Duration(3.0))]
+        start_joint_state.goal_time_tolerance = rospy.Duration(1)
         self.client.send_goal(start_joint_state)
         self.client.wait_for_result()
 
@@ -90,6 +91,7 @@ class IntegrationTest(unittest.TestCase):
 
         start_joint_state.trajectory.points = [
             JointTrajectoryPoint(positions=q_start, time_from_start=rospy.Duration(3.0))]
+        start_joint_state.goal_time_tolerance = rospy.Duration(1)
         self.client.send_goal(start_joint_state)
         self.client.wait_for_result()
 
@@ -110,6 +112,7 @@ class IntegrationTest(unittest.TestCase):
 
         start_joint_state.trajectory.points = [
             JointTrajectoryPoint(positions=self.joint_map.values(), time_from_start=rospy.Duration(3.0))]
+        start_joint_state.goal_time_tolerance = rospy.Duration(1)
         self.client.send_goal(start_joint_state)
         self.client.wait_for_result()
 


### PR DESCRIPTION
**Problem**
As pointed out by @fmauch [here](#17) and with the help of [these plots](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/1#issuecomment-549894865), the robot drivers' feedback (for the Universal Robots in this case) might not be concise enough for open-loop trajectory passthrough when being in _protective stop_ or similar blocking states. We need to inform the `PassThroughController`'s action client that the trajectory is not being executed as expected.

**Approach**
- The RobotHW now declares the trajectory execution done by calling a special method in the trajectory interface.
- The passthrough controllers themselves only warn when the time is up but do not stop trajectory execution.

Fixes #17 